### PR TITLE
Fix names in preprocessor directives

### DIFF
--- a/ast/if_else_node.h
+++ b/ast/if_else_node.h
@@ -1,6 +1,6 @@
 // $Id: if_else_node.h,v 1.1 2014/05/02 22:33:16 david Exp $ -*- c++ -*-
-#ifndef __CDK_IFELSENODE_H__
-#define __CDK_IFELSENODE_H__
+#ifndef __SIMPLE_IFELSENODE_H__
+#define __SIMPLE_IFELSENODE_H__
 
 #include <cdk/ast/expression_node.h>
 

--- a/ast/if_node.h
+++ b/ast/if_node.h
@@ -1,6 +1,6 @@
 // $Id: if_node.h,v 1.1 2014/05/02 22:33:16 david Exp $ -*- c++ -*-
-#ifndef __CDK_IFNODE_H__
-#define __CDK_IFNODE_H__
+#ifndef __SIMPLE_IFNODE_H__
+#define __SIMPLE_IFNODE_H__
 
 #include <cdk/ast/expression_node.h>
 

--- a/ast/while_node.h
+++ b/ast/while_node.h
@@ -1,6 +1,6 @@
 // $Id: while_node.h,v 1.1 2014/05/02 22:33:16 david Exp $ -*- c++ -*-
-#ifndef __CDK_WHILENODE_H__
-#define __CDK_WHILENODE_H__
+#ifndef __SIMPLE_WHILENODE_H__
+#define __SIMPLE_WHILENODE_H__
 
 #include <cdk/ast/expression_node.h>
 


### PR DESCRIPTION
Changed `CDK` to `SIMPLE` in preprocessor directives of if, if/else and while nodes